### PR TITLE
Implement staging-only capture pipeline and robust region handling

### DIFF
--- a/rapidshot/_libs/dxgi.py
+++ b/rapidshot/_libs/dxgi.py
@@ -142,7 +142,7 @@ class DXGI_MAPPED_RECT(ctypes.Structure):
     """
     DXGI mapped rectangle.
     """
-    _fields_ = [("Pitch", wintypes.INT), ("pBits", ctypes.POINTER(wintypes.FLOAT))]
+    _fields_ = [("Pitch", wintypes.INT), ("pBits", ctypes.c_void_p)]
 
 
 class IDXGIObject(comtypes.IUnknown):

--- a/rapidshot/memory_pool.py
+++ b/rapidshot/memory_pool.py
@@ -270,4 +270,3 @@ class CupyMemoryPool(BaseMemoryPool):
             # but this affects all CuPy allocations:
             # import cupy as cp
             # cp.get_default_memory_pool().free_all_blocks()
-```

--- a/rapidshot/processor/base.py
+++ b/rapidshot/processor/base.py
@@ -83,7 +83,7 @@ class Processor:
         except ImportError:
             pass
 
-    def process(self, rect, width, height, region, rotation_angle):
+    def process(self, rect, width, height, region, rotation_angle, output_buffer: Optional[Any] = None):
         """
         Process a frame.
         
@@ -97,7 +97,7 @@ class Processor:
         Returns:
             Processed frame
         """
-        return self.backend.process(rect, width, height, region, rotation_angle)
+        return self.backend.process(rect, width, height, region, rotation_angle, output_buffer)
     
     def process2(self, image_ptr, rect, width, height):
         """

--- a/rapidshot/util/ctypes_helpers.py
+++ b/rapidshot/util/ctypes_helpers.py
@@ -1,0 +1,49 @@
+"""Utility helpers for working with ctypes values."""
+
+from __future__ import annotations
+
+import ctypes
+from typing import Optional, Union
+
+
+def pointer_to_address(ptr: Union[int, ctypes.c_void_p, ctypes._Pointer]) -> Optional[int]:
+    """Return the integer address represented by *ptr*.
+
+    Parameters
+    ----------
+    ptr:
+        A ctypes pointer-like object or an integer address.
+
+    Returns
+    -------
+    Optional[int]
+        The integer address, or ``None`` if *ptr* does not represent a
+        valid address.
+    """
+
+    if ptr is None:
+        return None
+
+    if isinstance(ptr, int):
+        return ptr
+
+    if isinstance(ptr, ctypes.c_void_p):
+        return ptr.value
+
+    try:
+        value = ctypes.cast(ptr, ctypes.c_void_p).value
+        if value is not None:
+            return value
+    except (TypeError, ValueError):
+        pass
+
+    if hasattr(ptr, "value") and ptr.value is not None:
+        return ptr.value
+
+    if hasattr(ptr, "contents"):
+        try:
+            return ctypes.addressof(ptr.contents)
+        except (TypeError, ValueError):
+            return None
+
+    return None

--- a/rapidshot/util/timer.py
+++ b/rapidshot/util/timer.py
@@ -37,3 +37,9 @@ def set_periodic_timer(handle, period: int):
 
 wait_for_timer = __kernel32.WaitForSingleObject
 cancel_timer = __kernel32.CancelWaitableTimer
+
+
+def close_timer(handle):
+    if handle and __kernel32.CloseHandle(handle) == 0:
+        raise ctypes.WinError()
+    return True

--- a/tests/test_region_mapping.py
+++ b/tests/test_region_mapping.py
@@ -1,0 +1,96 @@
+import pytest
+
+pytest.importorskip("comtypes")
+
+from rapidshot.capture import ScreenCapture
+
+
+class DummyOutput:
+    def __init__(self, surface_size, rotation_angle):
+        self._surface_size = surface_size
+        self._rotation_angle = rotation_angle
+
+    @property
+    def surface_size(self):
+        return self._surface_size
+
+    @property
+    def rotation_angle(self):
+        return self._rotation_angle
+
+
+class DummyBox:
+    def __init__(self):
+        self.left = self.top = self.right = self.bottom = 0
+
+
+def make_capture(width, height):
+    capture = object.__new__(ScreenCapture)
+    capture.width = width
+    capture.height = height
+    capture._sourceRegion = None
+    capture.shot_w = 0
+    capture.shot_h = 0
+    return capture
+
+
+@pytest.mark.parametrize(
+    "rotation, surface_size, region, expected",
+    [
+        (0, (8, 6), (1, 2, 4, 5), (1, 2, 4, 5)),
+        (90, (6, 8), (1, 2, 4, 5), (2, 2, 5, 5)),
+        (180, (8, 6), (1, 2, 4, 5), (4, 1, 7, 4)),
+        (270, (6, 8), (1, 2, 4, 5), (3, 1, 6, 4)),
+    ],
+)
+def test_region_to_memory_region(rotation, surface_size, region, expected):
+    capture = make_capture(8, 6)
+    output = DummyOutput(surface_size, rotation)
+    assert (
+        capture.region_to_memory_region(region, rotation, output)
+        == expected
+    )
+
+
+def test_region_to_memory_region_rotation_mismatch():
+    capture = make_capture(10, 10)
+    output = DummyOutput((10, 10), 90)
+    with pytest.raises(AssertionError):
+        capture.region_to_memory_region((0, 0, 5, 5), 0, output)
+
+
+def test_normalize_region_validates_without_side_effects():
+    capture = make_capture(12, 8)
+    normalized = capture._normalize_region((1, 2, 6, 7))
+    assert normalized == (1, 2, 6, 7)
+    # Calling normalize should not set capture.region
+    assert not hasattr(capture, "region")
+
+
+@pytest.mark.parametrize(
+    "region",
+    [
+        (-1, 0, 2, 2),
+        (0, -1, 2, 2),
+        (0, 0, 13, 1),
+        (0, 0, 1, 9),
+        (4, 4, 3, 5),
+    ],
+)
+def test_normalize_region_invalid(region):
+    capture = make_capture(12, 8)
+    with pytest.raises(ValueError):
+        capture._normalize_region(region)
+
+
+def test_validate_region_updates_state():
+    capture = make_capture(20, 10)
+    capture._sourceRegion = DummyBox()
+    capture._validate_region((2, 3, 10, 9))
+    assert capture.region == (2, 3, 10, 9)
+    assert capture.shot_w == 8
+    assert capture.shot_h == 6
+    assert capture._sourceRegion.left == 2
+    assert capture._sourceRegion.top == 3
+    assert capture._sourceRegion.right == 10
+    assert capture._sourceRegion.bottom == 9


### PR DESCRIPTION
## Summary
- treat DXGI mapped rect pointers as raw addresses and add a shared helper to retrieve addresses for numpy, cupy, and pillow processors
- remove the direct GPU mapping path, always copy via the staging surface, and ensure frames are released only by callers while keeping timer handles and threads idempotent
- harden region validation/rotation, gate Windows-specific imports so memory_pool can load without COM, and add tests covering region rotation mappings

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2d82c11cc832d8fe3f596c1984d39